### PR TITLE
Enable rounded corners on all windows

### DIFF
--- a/src/Dm8Main/App.xaml
+++ b/src/Dm8Main/App.xaml
@@ -2,8 +2,9 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-             xmlns:dgext="urn:tom-englert.de/DataGridExtensions"
-             xmlns:b="clr-namespace:Dm8Main.Base"
+            xmlns:dgext="urn:tom-englert.de/DataGridExtensions"
+            xmlns:b="clr-namespace:Dm8Main.Base"
+            xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
              xmlns:local="clr-namespace:Dm8Main">
     <Application.Resources>
@@ -26,6 +27,9 @@
                 <ResourceDictionary Source="pack://application:,,,/Fluent;component/Themes/Generic.xaml" />
 
             </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="{x:Type controls:MetroWindow}">
+                <EventSetter Event="SourceInitialized" Handler="OnWindowSourceInitialized" />
+            </Style>
         </ResourceDictionary>
         
     </Application.Resources>

--- a/src/Dm8Main/App.xaml.cs
+++ b/src/Dm8Main/App.xaml.cs
@@ -161,6 +161,11 @@ namespace Dm8Main
             containerRegistry.RegisterDialog<DlgCoreAttributeAssign>();
         }
 
+        private void OnWindowSourceInitialized(object? sender, EventArgs e)
+        {
+            (sender as Window)?.EnableRoundedCorners();
+        }
+
         public static void Wait(bool set)
         {
             if (set)

--- a/src/Dm8Main/Base/WindowExt.cs
+++ b/src/Dm8Main/Base/WindowExt.cs
@@ -56,5 +56,48 @@ namespace Dm8Main.Base
             {
             }
         }
+
+        public static void EnableRoundedCorners(this Window This)
+        {
+            try
+            {
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    var hwnd = new System.Windows.Interop.WindowInteropHelper(This).Handle;
+                    if (hwnd != IntPtr.Zero)
+                    {
+                        var preference = Dm8Main.Base.WindowExt.DwmWindowCornerPreference.DWMWCP_ROUND;
+                        _ = Dm8Main.Base.WindowExt.DwmSetWindowAttribute(
+                            hwnd,
+                            Dm8Main.Base.WindowExt.DwmWindowAttribute.DWMWA_WINDOW_CORNER_PREFERENCE,
+                            ref preference,
+                            sizeof(uint));
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private enum DwmWindowAttribute
+        {
+            DWMWA_WINDOW_CORNER_PREFERENCE = 33
+        }
+
+        private enum DwmWindowCornerPreference
+        {
+            DWMWCP_DEFAULT = 0,
+            DWMWCP_DONOTROUND = 1,
+            DWMWCP_ROUND = 2,
+            DWMWCP_ROUNDSMALL = 3
+        }
+
+        [System.Runtime.InteropServices.DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(
+            IntPtr hwnd,
+            DwmWindowAttribute attribute,
+            ref DwmWindowCornerPreference pvAttribute,
+            int cbAttribute);
     }
 }


### PR DESCRIPTION
## Summary
- add helper to enable rounded corners via DWM
- call helper for each MetroWindow in App resources
- hook event handler in App code

## Testing
- `dotnet build src/Dm8Main/Dm8Main.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686c027cf36883239a4d858acdc4ef44